### PR TITLE
Refactor get content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",

--- a/js/cedar.handlebars.js
+++ b/js/cedar.handlebars.js
@@ -33,6 +33,24 @@ Handlebars.registerHelper('cedar', function(options) {
     } else {
       return false;
     }
+  };
+
+  var replaceElement = function(id, content) {
+    // If rendered element exists than insert the content
+    var renderedEl = document.getElementById(id);
+    if (renderedEl !== null) {
+      var parentEl = renderedEl.parentNode;
+      var tempEl = document.createElement("div");
+      tempEl.innerHTML = content;
+
+      // Insert content node by node and then remove the existing element
+      var nodeList = tempEl.childNodes;
+      var nodeListLength = nodeList.length;
+      for(var i = 0; i < nodeListLength; i++) {
+        parentEl.insertBefore(nodeList[0], renderedEl);
+      }
+      parentEl.removeChild(renderedEl);
+    }
   }
 
   var tagName = options.hash.tagName || "span";
@@ -58,21 +76,7 @@ Handlebars.registerHelper('cedar', function(options) {
       output = contentEntry.getContent();
     }
 
-    // If rendered element exists than insert the content
-    var renderedEl = document.getElementById(outputEl.id);
-    if (renderedEl !== null) {
-      var parentEl = renderedEl.parentNode;
-      var tempEl = document.createElement("div");
-      tempEl.innerHTML = output;
-
-      // Insert content node by node and then remove the existing element
-      var nodeList = tempEl.childNodes;
-      var nodeListLength = nodeList.length;
-      for(var i = 0; i < nodeListLength; i++) {
-        parentEl.insertBefore(nodeList[0], renderedEl);
-      }
-      parentEl.removeChild(renderedEl);
-    }
+    replaceElement(outputEl.id, output);
   });
 
   return new Handlebars.SafeString(output || outputEl.outerHTML);


### PR DESCRIPTION
Simplifying the logic of retrieving content. Most of this is preliminary work, breaking things out into smaller reusable methods that will make things easier to extend and adapt. The only functionality change is that you no longer need to explicitly call `getAll` (previously named `fetch`). You can still do it ahead of time, or you can wait until `get`is called for the first time, which will also trigger a `getAll` if the version is out of date.

@jedmurdock 
