### PR TITLE
Cache remote requests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.0.5",
+  "version": "0.0.51",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",


### PR DESCRIPTION
This further improves the store to prevent duplicate requests being made on the server.

Also renames `getAll()` to a more appropriate `getRemote()`.

@jedmurdock 
