### PR TITLE
Default content handlebars attribute and renaming file

### DIFF
--- a/js/cedar.js
+++ b/js/cedar.js
@@ -68,7 +68,7 @@ Cedar.Application = function(options) {
   Cedar.config.fetch = this.options.fetch;
 
   if (Cedar.events === undefined) {
-    Cedar.events = jQuery({});
+    Cedar.events = new Cedar.Events();
   }
 
   if ( Cedar.store === null ) {
@@ -157,6 +157,25 @@ Cedar.Auth.prototype.isEditUrl = function() {
 
 Cedar.Auth.prototype.getLogOffURL = function() {
   return this.removeURLParameter(window.location.href, 'cdrlogin');
+};
+
+/**
+ * Cedar.Events
+ */
+Cedar.Events = function() {
+  this.eventCollection = {};
+};
+
+Cedar.Events.prototype.trigger = function(eventName) {
+  if (!this.eventCollection[eventName]) {
+    this.eventCollection[eventName] = document.createEvent('Event');
+    this.eventCollection[eventName].initEvent(eventName, true, true);
+  }
+  document.dispatchEvent(this.eventCollection[eventName]);
+};
+
+Cedar.Events.prototype.on = function(eventName, eventCallback) {
+  document.addEventListener(eventName, eventCallback);
 };
 
 // adapted from stackoverflow:

--- a/js/cedar.js
+++ b/js/cedar.js
@@ -128,6 +128,24 @@ Cedar.Application.prototype.showGlobalActions = function() {
   });
 };
 
+/**
+ * Cedar.Events
+ */
+Cedar.Events = function() {
+  this.eventCollection = {};
+};
+
+Cedar.Events.prototype.trigger = function(eventName) {
+  if (!this.eventCollection[eventName]) {
+    this.eventCollection[eventName] = document.createEvent('Event');
+    this.eventCollection[eventName].initEvent(eventName, true, true);
+  }
+  document.dispatchEvent(this.eventCollection[eventName]);
+};
+
+Cedar.Events.prototype.on = function(eventName, eventCallback) {
+  document.addEventListener(eventName, eventCallback);
+};
 
 /**
  * Cedar.Auth
@@ -157,25 +175,6 @@ Cedar.Auth.prototype.isEditUrl = function() {
 
 Cedar.Auth.prototype.getLogOffURL = function() {
   return this.removeURLParameter(window.location.href, 'cdrlogin');
-};
-
-/**
- * Cedar.Events
- */
-Cedar.Events = function() {
-  this.eventCollection = {};
-};
-
-Cedar.Events.prototype.trigger = function(eventName) {
-  if (!this.eventCollection[eventName]) {
-    this.eventCollection[eventName] = document.createEvent('Event');
-    this.eventCollection[eventName].initEvent(eventName, true, true);
-  }
-  document.dispatchEvent(this.eventCollection[eventName]);
-};
-
-Cedar.Events.prototype.on = function(eventName, eventCallback) {
-  document.addEventListener(eventName, eventCallback);
 };
 
 // adapted from stackoverflow:

--- a/js/cedar.js
+++ b/js/cedar.js
@@ -7,8 +7,9 @@ window.Cedar = $.extend({}, window.Cedar, {
   store: null,
   auth: null
 });
-window.Cedar.config = window.Cedar.config || {}
-window.Cedar.config = $.extend({}, window.Cedar.config, {});
+window.Cedar.config = window.Cedar.config || {
+  liveMode: true
+};
 
 /**
 * Cedar.Init

--- a/js/cedar_handlebars.js
+++ b/js/cedar_handlebars.js
@@ -65,7 +65,7 @@ Handlebars.registerHelper('cedar', function(options) {
 
   var type = options.hash.type || 'ContentEntry';
 
-  new window.Cedar[type]({ cedarId: options.hash.id }).load().then(function(contentEntry){
+  new window.Cedar[type]({ cedarId: options.hash.id, defaultContent: options.hash.default }).load().then(function(contentEntry){
     if (blockHelperStyle()) {
       if (Cedar.auth.isEditMode()) {
         output += contentEntry.getEditOpen();


### PR DESCRIPTION
This adds a `default` parameter to the handlebars helper which defines default content to use in cases where localStorage is empty and there is no remote connection, or when a remote connection is not desired (such as automated testing). It also renames the handlebars helper file name to be improve compatibility with Rails.

@jedmurdock 
