### PR TITLE
Store by object type

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.0.76",
+  "version": "0.2.77",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "jquery": "~2.1.3",
-    "underscore": "~1.8.3"
+    "underscore.inflection": "~1.2.0",
+    "underscore.string": "~3.1.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "jquery": "~2.1.3"
+    "jquery": "~2.1.3",
+    "underscore": "~1.8.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.2.77",
+  "version": "0.2.78",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.0.63",
+  "version": "0.0.76",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",

--- a/js/cedar.js
+++ b/js/cedar.js
@@ -7,9 +7,7 @@ window.Cedar = $.extend({}, window.Cedar, {
   store: null,
   auth: null
 });
-window.Cedar.config = window.Cedar.config || {
-  liveMode: true
-};
+window.Cedar.config = window.Cedar.config || {};
 
 /**
 * Cedar.Init
@@ -53,10 +51,11 @@ Cedar.Application = function(options) {
     fetch: true,
     wait: false,
     forceHttps: false,
-    objectNameFilter: ''
+    objectNameFilter: '',
+    liveMode: true
   };
 
-  this.options = $.extend({}, defaults, options);
+  this.options = $.extend({}, $.extend({}, window.Cedar.config, defaults), options);
 
   if (this.options.server === undefined) {
     throw 'Cedar Error: must provide "server" value on Init()';
@@ -68,6 +67,7 @@ Cedar.Application = function(options) {
   Cedar.config.wait = this.options.wait;
   Cedar.config.fetch = this.options.fetch;
   Cedar.config.objectNameFilter = this.options.objectNameFilter;
+  Cedar.config.liveMode = this.options.liveMode;
 
   if (Cedar.events === undefined) {
     Cedar.events = new Cedar.Events();
@@ -288,7 +288,9 @@ Cedar.Store.prototype.getDeferred = function(type, attributes) {
   var remoteDeferred = this.remoteDeferred(type, attributes);
 
   if (Cedar.config.wait || _(this.cachedObject(type, attributes)).isEmpty()) {
-    Cedar.debug('checking remote: ' + type + '/' + JSON.stringify(attributes));
+    if (Cedar.config.liveMode) {
+      Cedar.debug('checking remote: ' + type + '/' + JSON.stringify(attributes));
+    }
     return remoteDeferred;
   } else {
     Cedar.debug('get from cache: ' + type + '/' + JSON.stringify(attributes));

--- a/js/cedar_handlebars.js
+++ b/js/cedar_handlebars.js
@@ -64,18 +64,22 @@ Handlebars.registerHelper('cedar', function(options) {
   var output = '';
 
   var type = options.hash.type || 'ContentEntry';
+  var cedarClass = blockHelperStyle() ? 'ContentObject' : 'ContentEntry'
 
-  new window.Cedar[type]({ cedarId: options.hash.id, defaultContent: options.hash.default }).load().then(function(contentEntry){
+  Cedar.store.get(type, {id: options.hash.id}).then(function(data){
+    var cedarObject = new window.Cedar[cedarClass]({ cedarId: options.hash.id, cedarType: type, defaultContent: options.hash.default });
+    cedarObject.setContent(data);
+
     if (blockHelperStyle()) {
       if (Cedar.auth.isEditMode()) {
-        output += contentEntry.getEditOpen();
+        output += cedarObject.getEditOpen();
       }
-      output += unescapeHtml(options.fn(contentEntry.toJSON()));
+      output += unescapeHtml(options.fn(cedarObject.toJSON()));
       if (Cedar.auth.isEditMode()) {
-        output += contentEntry.getEditClose();
+        output += cedarObject.getEditClose();
       }
     } else {
-      output = contentEntry.toString();
+      output = cedarObject.toString();
     }
 
     replaceElement(outputEl.id, output);


### PR DESCRIPTION
This changes the way data is stored in localStorage so that it is stored by type. Also adds a query-able interface to the localStorage data. Also factors out Mazlo-specific functionality into configurable options.
