### PR TITLE
Separated administrative/edit-mode functionality to it's own independent JS class

### DIFF
--- a/js/cedar_admin.js
+++ b/js/cedar_admin.js
@@ -1,0 +1,112 @@
+Cedar.Admin = function() {
+  if (this.isEditMode()) {
+    this.showGlobalActions();
+  }
+
+  $(document).on("DOMContentLoaded", _.bind(function(event) {
+    if (this.isEditMode()) {
+      this.scanDOM();
+    }
+  }, this));
+};
+
+Cedar.Admin.prototype.scanDOM = function() {
+  $('[data-cedar-id]').each(_.bind(function(index, el){
+    var $el = $(el);
+    var editTools = $(this.getEditTools($el.data()));
+    $el.prepend(editTools);
+    $el.addClass("cedar-cms-editable clearfix");
+  }, this));
+};
+
+Cedar.Admin.prototype.isEditMode = function() {
+  return this.isEditUrl();
+};
+
+Cedar.Admin.prototype.isEditUrl = function() {
+  var sPageURL = window.location.search.substring(1);
+  var sURLVariables = sPageURL.split('&');
+  var i = 0;
+  while (i < sURLVariables.length) {
+    if (sURLVariables[i] === 'cdrlogin') {
+      return true;
+    }
+    i++;
+  }
+  return false;
+};
+
+Cedar.Admin.prototype.showGlobalActions = function() {
+  $(document).ready(_.bind(function() {
+    var $body = $('body');
+    var globalActions = '<div class="cedar-cms-global-actions">' +
+      '<a href="#" class="cedar-cms-global-action" onclick="window.location.reload();">' +
+      '<span class="cedar-cms-icon cedar-cms-icon-edit"></span> ' +
+      '<span class="cedar-cms-global-action-label">Refresh</span>' +
+      '</a><br>' +
+      '<a class="cedar-cms-global-action" href="' + this.getLogOffURL() + '">' +
+      '<span class="cedar-cms-icon cedar-cms-icon-edit"></span> ' +
+      '<span class="cedar-cms-global-action-label">Log Off Cedar</span>' +
+      '</a>' +
+      '</div>';
+    $body.append(globalActions);
+  }, this));
+};
+
+Cedar.Admin.prototype.getLogOffURL = function() {
+  return this.removeURLParameter(window.location.href, 'cdrlogin');
+};
+
+Cedar.Admin.prototype.getEditTools = function(options) {
+  var jsString = "if(event.stopPropagation){event.stopPropagation();}" +
+  "event.cancelBubble=true;" +
+  "window.location.href=this.attributes.href.value + \'&referer=' + encodeURIComponent(window.location.href) + '\';" +
+  "return false;";
+
+  var block = '<span class="cedar-cms-edit-tools">';
+  block += '<a onclick="' + jsString + '" href="' + Cedar.config.server +
+           '/cmsadmin/EditData?cdr=1&t=' +
+           options.cedarType +
+           '&o=' +
+           encodeURIComponent(options.cedarId) +
+           '" class="cedar-cms-edit-icon cedar-js-edit" >';
+  block += '<i class="cedar-cms-icon cedar-cms-icon-right cedar-cms-icon-edit"></i></a>';
+  block += '</span>';
+  return block;
+};
+
+// adapted from stackoverflow:
+// http://stackoverflow.com/questions/1634748/how-can-i-delete-a-query-string-parameter-in-javascript
+Cedar.Admin.prototype.removeURLParameter = function(url, parameter) {
+  var splitUrl = url.split('#');
+  var serverUrl = splitUrl[0];
+  var clientUrl = splitUrl[1] || '';
+  if (clientUrl) {
+    clientUrl = '#' + clientUrl;
+  }
+  // prefer to use l.search if you have a location/link object
+  var splitServerUrl= serverUrl.split('?');
+  if (splitServerUrl.length>=2) {
+
+    var prefix = encodeURIComponent(parameter); //+'=';
+    var pars = splitServerUrl[1].split(/[&;]/g);
+
+    //reverse iteration as may be destructive
+    var i = pars.length - 1;
+    while (i >= 0) {
+      // idiom for string.startsWith
+      if (pars[i].lastIndexOf(prefix, 0) !== -1) {
+        pars.splice(i, 1);
+      }
+      i--;
+    }
+
+    var updatedServerUrl= splitServerUrl[0];
+    if (pars.length > 0) {
+      updatedServerUrl += '?'+pars.join('&');
+    }
+    return updatedServerUrl + clientUrl;
+  } else {
+    return url;
+  }
+};


### PR DESCRIPTION
This change removes the current `Cedar.Auth` class (and other edit mode functionality) and replaces it with an independent class `Cedar.Admin`. Now, instead of having the `Cedar.ContentEntry` simply output edit mode HTML/hyperlink, `Cedar.admin.scanDOM()` is triggered at the appropriate time to search the DOM for elements that are wrapped in `cedar` tags (which will be the case when edit mode is enabled).

This scanning of the DOM is totally independent of the SPA integration built for Mazlo, and could be triggered to search for `cedar` wrapped content generated by any means (ie. from a server-side PHP process).

Next step is to test it with a PHP demo. I'm leaving it all a part of this repo for now, but it will likely be split out in the future.

@millera @jedmurdock 
