### PR TITLE
Add class to load within admin site to handle iframeMode behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cedar",
-  "version": "0.2.91",
+  "version": "0.2.92",
   "homepage": "https://github.com/plyinteractive/cdr-js",
   "authors": [
     "Jed Murdock <jed@plyinteractive.com",

--- a/js/cedar_iframe.js
+++ b/js/cedar_iframe.js
@@ -1,0 +1,63 @@
+(function() {
+  window.Cedar = window.Cedar || {};
+
+  /**
+  * Cedar.Iframe
+  *
+  * Class for handling "iframe mode" of Cedar CMS admin screens
+  *
+  */
+  Cedar.Iframe = function(options) {
+    var defaults = {
+      originCookieName: "cedarContentOrigin"
+    };
+
+    this.options = $.extend({}, $.extend({}, defaults, window.Cedar.config), options);
+
+    if (this.isIframeMode()) {
+      this.listenToParent();
+      this.processDOM();
+    }
+  };
+
+  Cedar.Iframe.prototype.isIframeMode = function() {
+    return window.location.search.indexOf('iframeMode') >= 0;
+  };
+
+  Cedar.Iframe.prototype.listenToParent = function() {
+    $(window).on("message", _.bind(function(event){
+      document.cookie = this.options.originCookieName + "=" + event.originalEvent.origin;
+    }, this));
+  };
+
+  Cedar.Iframe.prototype.callParentMethod = function(methodName) {
+    window.parent.postMessage(methodName, this.getCookie(this.options.originCookieName));
+  };
+
+  Cedar.Iframe.prototype.parentHideIframe = function() {
+    this.callParentMethod('hideIframe');
+  };
+
+  Cedar.Iframe.prototype.parentReload = function() {
+    this.callParentMethod('hideIframeReload');
+  };
+
+  Cedar.Iframe.prototype.processDOM = function() {
+    $('.cms-dashboard').hide();
+    $('#cmsToolbarPlaceholder').hide();
+    var iframeForm = $('#editForm');
+    iframeForm.on('submit', _.bind(this.parentReload, this));
+    iframeForm.find('.s-cancel-edit').click(_.bind(this.parentHideIframe, this));
+  };
+
+  Cedar.Iframe.prototype.getCookie = function(cname) {
+      var name = cname + "=";
+      var ca = document.cookie.split(';');
+      for(var i=0; i<ca.length; i++) {
+          var c = ca[i];
+          while (c.charAt(0)==' ') c = c.substring(1);
+          if (c.indexOf(name) == 0) return c.substring(name.length,c.length);
+      }
+      return "";
+  };
+})();


### PR DESCRIPTION
This adds a `Cedar.Iframe` class which will need to be installed and initialized within any Ply CMS admin site. Once that is done, any Cedar site that points to the API URL of that CMS instance running in `inlineEditing` mode will be able to communicate method calls cross-domain. IE. hitting "cancel" or "publish" will cause the iframe to collapse (and page to refresh on publish). These basic features are done, but included in this PR are the building blocks for more complex functionality as needed.

I also have the iframe disabling certain DOM objects within the admin mode screens if it is in `iframeMode` (indicated by an `iframeMode` URL variable being preset). We may want to switch to server-side to handle this, but it's fine for now.

@shenst1 @millera 
